### PR TITLE
Fix zizmor template injection warning in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,8 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          gh release create "${{ github.ref_name }}" \
+          gh release create "$TAG_NAME" \
             dist/mitre-attack-obsidian-standard.zip \
             dist/mitre-attack-obsidian-embedded.zip


### PR DESCRIPTION
Pass github.ref_name via an env variable (TAG_NAME) rather than interpolating the expression directly into the shell script, eliminating the potential template injection vector flagged by zizmor.

https://claude.ai/code/session_011y1TuBggwJiRUjuBwx5REN